### PR TITLE
Remove statement by author (no longer required)

### DIFF
--- a/dissertation.tex
+++ b/dissertation.tex
@@ -90,13 +90,6 @@
 {Edgar Elm} % 4th committee member (leave empty if None)
 {} % 5th committee member (leave empty if None)
 
-% Include the ``Statement by Author'' for Dissertations
-\statementbyauthor
-% If this is a Thesis, use the following form, with your thesis director's
-% name and title in the square brackets like so (you should also omit the 
-% approval form insertion above):
-%\statementbyauthor[Jane M. Doe\\Professor of Chemistry]
-
 % Include the ``Acknowledgements''
 \incacknowledgements{acknowledgements}
 


### PR DESCRIPTION
The statement by author is no longer required by the graduate college as of Fall 2018.